### PR TITLE
move go packages to lacruzgit

### DIFF
--- a/cmd/sqlread/main.go
+++ b/cmd/sqlread/main.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 
 	bufra "github.com/avvmoto/buf-readerat"
-	"github.com/tespeleta/sqlread"
-	"github.com/tespeleta/sqlread/mapcache"
+	"github.com/lacruzgit/sqlread"
+	"github.com/lacruzgit/sqlread/mapcache"
 )
 
 var filename string

--- a/cmd/sqlread/query.go
+++ b/cmd/sqlread/query.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"sort"
 
-	"github.com/tespeleta/sqlread"
+	"github.com/lacruzgit/sqlread"
 )
 
 type DataWriter interface {

--- a/debug/lexer.go
+++ b/debug/lexer.go
@@ -1,7 +1,7 @@
 package debug
 
 import (
-	"github.com/tespeleta/sqlread"
+	"github.com/lacruzgit/sqlread"
 )
 
 func LexTunnel(in chan sqlread.LexItem, cb func(c sqlread.LexItem)) chan sqlread.LexItem {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tespeleta/sqlread
+module github.com/lacruzgit/sqlread
 
 go 1.12
 

--- a/mapcache/cache.go
+++ b/mapcache/cache.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"os"
 
-	"github.com/tespeleta/sqlread"
+	"github.com/lacruzgit/sqlread"
 )
 
 // CacheVersion is incremented when the structure of the cache changes


### PR DESCRIPTION
golang requires the packages to be namespaces correctly: removing all references to tespeleta user